### PR TITLE
fix: production build

### DIFF
--- a/client/src/tailwind.config.js
+++ b/client/src/tailwind.config.js
@@ -164,7 +164,7 @@ const stateLayers = {
   "primary": "#6750A4",
 };
 
-module.exports = {
+const config = {
   content: ["./**/src/**/*.{tsx, ts, jsx, js}"],
   theme: {
     extend: {
@@ -197,3 +197,5 @@ module.exports = {
     require("@tailwindcss/aspect-ratio"),
   ],
 };
+
+export default config;

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,2 +1,0 @@
-// Please configure Tailwind in src/tailwind.config.js instead of this file.
-module.exports = require("./src/tailwind.config");

--- a/client/tailwind.config.mjs
+++ b/client/tailwind.config.mjs
@@ -1,0 +1,4 @@
+// Please configure Tailwind in src/tailwind.config.js instead of this file.
+import tailwindConfig from "./src/tailwind.config";
+
+export default tailwindConfig;


### PR DESCRIPTION
- Files under src/ are usually ES Modules (a.k.a. use import/export). 
- Files outside of src/ are usually CommonJS (a.k.a. use require, module.exports).
- This PR makes the tailwind config inside src/ be an ES Module and the top-level tailwind config have .mjs extension so that it's an ES Module which then imports the ES Module inside src/. 
- Looks like it works