### PR TITLE
Course failure handling and frontend optimization

### DIFF
--- a/client/src/Utilities.tsx
+++ b/client/src/Utilities.tsx
@@ -59,4 +59,20 @@ const classnames = (...args: ClassNameValue[]) => {
   return classnames(...args);
 };
 
-export { classnames };
+const formatDate = (dateString: string): string | null => {
+  try {
+    const date = new Date(dateString);
+    return date.toLocaleString("en-US", {
+      month: "long",
+      day: "numeric",
+      year: "numeric",
+      hour: "numeric",
+      minute: "numeric",
+      hour12: false,
+    });
+  } catch (e) {
+    return null;
+  }
+};
+
+export { classnames, formatDate };

--- a/client/src/Utilities.tsx
+++ b/client/src/Utilities.tsx
@@ -59,20 +59,4 @@ const classnames = (...args: ClassNameValue[]) => {
   return classnames(...args);
 };
 
-const formatDate = (dateString: string): string | null => {
-  try {
-    const date = new Date(dateString);
-    return date.toLocaleString("en-US", {
-      month: "long",
-      day: "numeric",
-      year: "numeric",
-      hour: "numeric",
-      minute: "numeric",
-      hour12: false,
-    });
-  } catch (e) {
-    return null;
-  }
-};
-
-export { classnames, formatDate };
+export { classnames };

--- a/client/src/components/AssessmentCard/AssessmentCard.tsx
+++ b/client/src/components/AssessmentCard/AssessmentCard.tsx
@@ -9,18 +9,6 @@ interface AssessmentCardProps {
 }
 
 const AssessmentCard = ({ assessment, onAssessmentClick }: AssessmentCardProps) => {
-  function formatDate(dateString: string): string {
-    const date = new Date(dateString);
-    return date.toLocaleString("en-US", {
-      month: "long",
-      day: "numeric",
-      year: "numeric",
-      hour: "numeric",
-      minute: "numeric",
-      hour12: false,
-    });
-  }
-
   return (
     <Button
       className={classnames(
@@ -38,7 +26,13 @@ const AssessmentCard = ({ assessment, onAssessmentClick }: AssessmentCardProps) 
         <img
           src={blob}
           alt="assessment icon background"
-          className={classnames("absolute", "top-0", "left-0", "w-full", "h-full")}
+          className={classnames(
+            "absolute",
+            "top-0",
+            "left-0",
+            "w-full",
+            "h-full"
+          )}
         />
         <span
           className={classnames(
@@ -54,13 +48,19 @@ const AssessmentCard = ({ assessment, onAssessmentClick }: AssessmentCardProps) 
           )}
         >
           {
-            ["event", "star"][Math.floor((assessment.name.charCodeAt(0) + 1) % 2)] // TODO: replace with a better way to determine icon
+            ["event", "star"][
+              Math.floor((assessment.name.charCodeAt(0) + 1) % 2)
+            ] // TODO: replace with a better way to determine icon
           }
         </span>
       </div>
-      <div className={classnames("flex", "flex-col", "items-start", "text-left")}>
-        <h1 className="font-bold text-sys-on-tertiary-container">{assessment.name}</h1>
-        <h2>{formatDate(assessment.date)}</h2>
+      <div
+        className={classnames("flex", "flex-col", "items-start", "text-left")}
+      >
+        <h1 className="font-bold text-sys-on-primary-container">
+          {assessment.name}
+        </h1>
+        <h2>{assessment.dateFormatted}</h2>
         <p className="text-sys-outline mt-2">
           Weight: {assessment.weight}
           <br />

--- a/client/src/components/AssessmentCard/AssessmentCard.tsx
+++ b/client/src/components/AssessmentCard/AssessmentCard.tsx
@@ -8,6 +8,22 @@ interface AssessmentCardProps {
   onAssessmentClick: (assessment: Assessment) => void;
 }
 
+const formatDate = (dateString: string): string | null => {
+  try {
+    const date = new Date(dateString);
+    return date.toLocaleString("en-US", {
+      month: "long",
+      day: "numeric",
+      year: "numeric",
+      hour: "numeric",
+      minute: "numeric",
+      hour12: false,
+    });
+  } catch (e) {
+    return null;
+  }
+};
+
 const AssessmentCard = ({ assessment, onAssessmentClick }: AssessmentCardProps) => {
   return (
     <Button
@@ -60,7 +76,7 @@ const AssessmentCard = ({ assessment, onAssessmentClick }: AssessmentCardProps) 
         <h1 className="font-bold text-sys-on-primary-container">
           {assessment.name}
         </h1>
-        <h2>{assessment.dateFormatted}</h2>
+        <h2>{formatDate(assessment.date)}</h2>
         <p className="text-sys-outline mt-2">
           Weight: {assessment.weight}
           <br />

--- a/client/src/components/NavigationDrawer/NavigationDrawer.tsx
+++ b/client/src/components/NavigationDrawer/NavigationDrawer.tsx
@@ -1,19 +1,21 @@
 import axios from "axios";
 import { classnames } from "../../Utilities";
 import Button from "../Button";
-import jsonToICS, { Courses } from "../../logic/icsGen";
+import jsonToICS, { Course, Courses } from "../../logic/icsGen";
 import { useState, useRef } from "react";
 
 interface NavigationDrawerProps {
   courses: Courses;
-  currentCourseKey: string | undefined;
+  currentCourseKey: string | null;
   onCoursesChanged: (courses: Courses) => void;
+  onCourseClick: (course: Course) => void;
 }
 
 const NavigationDrawer = ({
   courses,
   currentCourseKey,
   onCoursesChanged,
+  onCourseClick,
 }: NavigationDrawerProps) => {
   const [loading, setLoading] = useState<string[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -58,7 +60,7 @@ const NavigationDrawer = ({
         courses.map((course, t) => (
           <Button
             variant="text"
-            to={`/app/${course.key}`}
+            onClick={() => onCourseClick(course)}
             key={t}
             className={classnames(
               "text-gray-900",

--- a/client/src/components/NavigationDrawer/NavigationDrawer.tsx
+++ b/client/src/components/NavigationDrawer/NavigationDrawer.tsx
@@ -54,13 +54,12 @@ const NavigationDrawer = ({
   return (
     <div className="flex flex-col w-full md:p-4 p-0 bg-surface">
       <p className="m-5 ml-2 font-bold">Courses</p>
-
       {courses &&
-        courses.map((course) => (
+        courses.map((course, t) => (
           <Button
             variant="text"
             to={`/app/${course.key}`}
-            key={course.key}
+            key={t}
             className={classnames(
               "text-gray-900",
               "mt-2",

--- a/client/src/components/NavigationDrawer/NavigationDrawer.tsx
+++ b/client/src/components/NavigationDrawer/NavigationDrawer.tsx
@@ -10,47 +10,55 @@ interface NavigationDrawerProps {
   onCoursesChanged: (courses: Courses) => void;
 }
 
-const NavigationDrawer = ({ courses, currentCourseKeyString, onCoursesChanged }: NavigationDrawerProps) => {
+const NavigationDrawer = ({
+  courses,
+  currentCourseKeyString,
+  onCoursesChanged,
+}: NavigationDrawerProps) => {
   const [loading, setLoading] = useState<string[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleOutlineUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
-    if (!files)
-      return;
+    if (!files) return;
     setLoading(Array.from(files).map((f: File) => f.name));
 
     const formData = new FormData();
     for (let i = 0; i < files.length; i++)
       formData.append("outline_files", files[i]);
 
-    axios.post("/files", formData, {
-      headers: { "Content-Type": "multipart/form-data" }
-    })
-      .then(res => {
-        // if they share a key, rename the new one
-        for (const key in res.data) {
-          if (key in courses) {
-            let i = 1;
-            while (`${key} (${i})` in courses)
-              i++;
-            res.data[`${key} (${i})`] = res.data[key];
-            delete res.data[key];
+    axios
+      .post("/files", formData, {
+        headers: { "Content-Type": "multipart/form-data" },
+      })
+      .then((res) => {
+        for (const course of res.data) {
+          if (!course.code || !course.number) {
+            course.code = "Course";
+            course.number = Object.values(courses).length + 1;
+            course.title = "Course";
           }
+
+          const key = `${course.code}-${course.number}`.toLowerCase();
+          course.key = key;
+          courses[key] = course;
         }
 
-        onCoursesChanged(res.data);
+        onCoursesChanged(courses);
       })
       .catch((error) => {
         console.log(error);
-      }).finally(() => {
+      })
+      .finally(() => {
         setLoading([]);
       });
   };
 
   const handleExport = () => {
     const a = document.createElement("a");
-    a.href = `data:text/plain;charset=utf-8,${encodeURIComponent(jsonToICS(courses))}`;
+    a.href = `data:text/plain;charset=utf-8,${encodeURIComponent(
+      jsonToICS(courses)
+    )}`;
     a.download = "deadlines.ics";
     a.click();
   };
@@ -59,39 +67,46 @@ const NavigationDrawer = ({ courses, currentCourseKeyString, onCoursesChanged }:
     <div className="flex flex-col w-full md:p-4 p-0 bg-surface">
       <p className="m-5 ml-2 font-bold">Courses</p>
 
-      {courses && Object.entries(courses).map(([courseKey, course]) => (
-        <Button
-          variant="text"
-          to={`/app/${courseKey}`}
-          key={courseKey}
-          className={classnames(
-            "text-gray-900",
-            "mt-2",
-            "flex",
-            "flex-row",
-            "p-4",
-            currentCourseKeyString === courseKey && "bg-primary-90",
-          )}
-        >
-          <span className="material-icons text-gray-600 text-base flex items-center justify-center">
-            {["circle", "square", "pentagon"][Math.abs(courseKey.split("").reduce((a, b) => a + b.charCodeAt(0), 0)) % 3]}
-          </span>
-          <div className="flex flex-col ml-2 min-w-0">
-            <p className="flex items-center font-bold">
-              {course.code} {course.number}
+      {courses &&
+        Object.entries(courses).map(([courseKey, course]) => (
+          <Button
+            variant="text"
+            to={`/app/${courseKey}`}
+            key={courseKey}
+            className={classnames(
+              "text-gray-900",
+              "mt-2",
+              "flex",
+              "flex-row",
+              "p-4",
+              currentCourseKeyString === courseKey && "bg-primary-90"
+            )}
+          >
+            <span className="material-icons text-gray-600 text-base flex items-center justify-center">
+              {
+                ["circle", "square", "pentagon"][
+                  Math.abs(
+                    courseKey.split("").reduce((a, b) => a + b.charCodeAt(0), 0)
+                  ) % 3
+                ]
+              }
+            </span>
+            <div className="flex flex-col ml-2 min-w-0">
+              <p className="flex items-center font-bold">
+                {course.code} {course.number}
+              </p>
+              <p className={classnames("truncate", "md:hidden")}>
+                {course.topic}
+              </p>
+            </div>
+            <p className="ml-auto flex items-center justify-center">
+              {course.assessments.length}
             </p>
-            <p className={classnames("truncate", "md:hidden")}>
-              {course.topic}
-            </p>
-          </div>
-          <p className="ml-auto flex items-center justify-center">
-            {course.assessments.length}
-          </p>
-          <span className="material-icons text-gray-600 flex items-center justify-center block md:hidden">
-            arrow_right
-          </span>
-        </Button>
-      ))}
+            <span className="material-icons text-gray-600 flex items-center justify-center block md:hidden">
+              arrow_right
+            </span>
+          </Button>
+        ))}
       {loading.length > 0 && (
         <div className="flex flex-col w-full">
           {loading.map((file) => (
@@ -99,15 +114,13 @@ const NavigationDrawer = ({ courses, currentCourseKeyString, onCoursesChanged }:
               variant="text"
               key={file}
               disabled
-              className={classnames("mt-2", "flex-row", "p-4",)}
+              className={classnames("mt-2", "flex-row", "p-4")}
             >
               <span className="material-icons text-gray-600 text-base flex items-center justify-center animate-spin">
                 autorenew
               </span>
               <div className="flex flex-col ml-2 min-w-0">
-                <p className={classnames("truncate")}>
-                  {file}
-                </p>
+                <p className={classnames("truncate")}>{file}</p>
               </div>
             </Button>
           ))}
@@ -134,27 +147,42 @@ const NavigationDrawer = ({ courses, currentCourseKeyString, onCoursesChanged }:
         >
           add
         </span>
-        <p className="flex items-center ml-2"
-          style={{ transform: "translateX(-0.4rem)", }}>
+        <p
+          className="flex items-center ml-2"
+          style={{ transform: "translateX(-0.4rem)" }}
+        >
           Add course
         </p>
       </Button>
       <hr className="border-gray-300 p-2 hidden md:block" />
-      <Button variant="filled"
+      <Button
+        variant="filled"
         // on mobile it sits in the absolute bottom right and is only as wide as the text. Has a shadow on mobile
-        className={classnames("fixed", "bottom-0", "right-0", "md:relative", "p-4", "m-5", "mb-10", "md:m-0", "shadow-lg", "md:shadow-none", "rounded-2xl", "md:rounded-3xl")}
+        className={classnames(
+          "fixed",
+          "bottom-0",
+          "right-0",
+          "md:relative",
+          "p-4",
+          "m-5",
+          "mb-10",
+          "md:m-0",
+          "shadow-lg",
+          "md:shadow-none",
+          "rounded-2xl",
+          "md:rounded-3xl"
+        )}
         onClick={handleExport}
       >
-        <span className="material-icons flex items-center justify-center"
+        <span
+          className="material-icons flex items-center justify-center"
           style={{ marginLeft: "-0.4rem" }}
         >
           save_alt
         </span>
-        <p className="flex items-center ml-2">
-          Export
-        </p>
+        <p className="flex items-center ml-2">Export</p>
       </Button>
-    </div >
+    </div>
   );
 };
 

--- a/client/src/components/NavigationDrawer/NavigationDrawer.tsx
+++ b/client/src/components/NavigationDrawer/NavigationDrawer.tsx
@@ -6,14 +6,14 @@ import { useState, useRef } from "react";
 
 interface NavigationDrawerProps {
   courses: Courses;
-  currentCourseKey: string | null;
+  currentCourse: Course | null;
   onCoursesChanged: (courses: Courses) => void;
   onCourseClick: (course: Course) => void;
 }
 
 const NavigationDrawer = ({
   courses,
-  currentCourseKey,
+  currentCourse,
   onCoursesChanged,
   onCourseClick,
 }: NavigationDrawerProps) => {
@@ -68,7 +68,7 @@ const NavigationDrawer = ({
               "flex",
               "flex-row",
               "p-4",
-              currentCourseKey === course.key && "bg-primary-90"
+              currentCourse?.key === course.key && "bg-primary-90"
             )}
           >
             <span className="material-icons text-gray-600 text-base flex items-center justify-center">

--- a/client/src/components/NavigationDrawer/NavigationDrawer.tsx
+++ b/client/src/components/NavigationDrawer/NavigationDrawer.tsx
@@ -14,8 +14,6 @@ const NavigationDrawer = ({ courses, currentCourseKeyString, onCoursesChanged }:
   const [loading, setLoading] = useState<string[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const urlFormat = (course: string) => (course.replace(/ /g, "-").toLowerCase());
-
   const handleOutlineUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
     if (!files)
@@ -61,33 +59,33 @@ const NavigationDrawer = ({ courses, currentCourseKeyString, onCoursesChanged }:
     <div className="flex flex-col w-full md:p-4 p-0 bg-surface">
       <p className="m-5 ml-2 font-bold">Courses</p>
 
-      {courses && Object.entries(courses).map(([course, courseData]) => (
+      {courses && Object.entries(courses).map(([courseKey, course]) => (
         <Button
           variant="text"
-          to={`/app/${urlFormat(course)}`}
-          key={course}
+          to={`/app/${courseKey}`}
+          key={courseKey}
           className={classnames(
             "text-gray-900",
             "mt-2",
             "flex",
             "flex-row",
             "p-4",
-            currentCourseKeyString === course && "bg-primary-90",
+            currentCourseKeyString === courseKey && "bg-primary-90",
           )}
         >
           <span className="material-icons text-gray-600 text-base flex items-center justify-center">
-            {["circle", "square", "pentagon"][Math.abs(course.split("").reduce((a, b) => a + b.charCodeAt(0), 0)) % 3]}
+            {["circle", "square", "pentagon"][Math.abs(courseKey.split("").reduce((a, b) => a + b.charCodeAt(0), 0)) % 3]}
           </span>
           <div className="flex flex-col ml-2 min-w-0">
             <p className="flex items-center font-bold">
-              {course}
+              {course.code} {course.number}
             </p>
             <p className={classnames("truncate", "md:hidden")}>
-              {courseData.topic}
+              {course.topic}
             </p>
           </div>
           <p className="ml-auto flex items-center justify-center">
-            {courseData.assessments.length}
+            {course.assessments.length}
           </p>
           <span className="material-icons text-gray-600 flex items-center justify-center block md:hidden">
             arrow_right

--- a/client/src/components/NavigationDrawer/NavigationDrawer.tsx
+++ b/client/src/components/NavigationDrawer/NavigationDrawer.tsx
@@ -6,13 +6,13 @@ import { useState, useRef } from "react";
 
 interface NavigationDrawerProps {
   courses: Courses;
-  currentCourseKeyString: string | undefined;
+  currentCourseKey: string | undefined;
   onCoursesChanged: (courses: Courses) => void;
 }
 
 const NavigationDrawer = ({
   courses,
-  currentCourseKeyString,
+  currentCourseKey,
   onCoursesChanged,
 }: NavigationDrawerProps) => {
   const [loading, setLoading] = useState<string[]>([]);
@@ -32,19 +32,7 @@ const NavigationDrawer = ({
         headers: { "Content-Type": "multipart/form-data" },
       })
       .then((res) => {
-        for (const course of res.data) {
-          if (!course.code || !course.number) {
-            course.code = "Course";
-            course.number = Object.values(courses).length + 1;
-            course.title = "Course";
-          }
-
-          const key = `${course.code}-${course.number}`.toLowerCase();
-          course.key = key;
-          courses[key] = course;
-        }
-
-        onCoursesChanged(courses);
+        onCoursesChanged(res.data);
       })
       .catch((error) => {
         console.log(error);
@@ -68,25 +56,25 @@ const NavigationDrawer = ({
       <p className="m-5 ml-2 font-bold">Courses</p>
 
       {courses &&
-        Object.entries(courses).map(([courseKey, course]) => (
+        courses.map((course) => (
           <Button
             variant="text"
-            to={`/app/${courseKey}`}
-            key={courseKey}
+            to={`/app/${course.key}`}
+            key={course.key}
             className={classnames(
               "text-gray-900",
               "mt-2",
               "flex",
               "flex-row",
               "p-4",
-              currentCourseKeyString === courseKey && "bg-primary-90"
+              currentCourseKey === course.key && "bg-primary-90"
             )}
           >
             <span className="material-icons text-gray-600 text-base flex items-center justify-center">
               {
                 ["circle", "square", "pentagon"][
                   Math.abs(
-                    courseKey.split("").reduce((a, b) => a + b.charCodeAt(0), 0)
+                    course.key.split("").reduce((a, b) => a + b.charCodeAt(0), 0)
                   ) % 3
                 ]
               }

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -8,7 +8,6 @@ import Landing from "./pages/Landing";
 import Loading from "./pages/Loading";
 import Review from "./pages/Review";
 
-
 const hostname = window.location.hostname;
 const port = window.location.port;
 
@@ -32,16 +31,15 @@ function App() {
           <Route path="/landing" element={<Landing />} />
           <Route path="/loading" element={<Loading />} />
           <Route path="/app" element={<Review />} />
-          <Route path="/app/:courseId" element={<Review />} />
+          <Route path="/app/:courseKey" element={<Review />} />
         </Routes>
       </BrowserRouter>
     </div>
   );
 }
 
-
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
+  </React.StrictMode>
 );

--- a/client/src/logic/icsGen.ts
+++ b/client/src/logic/icsGen.ts
@@ -7,6 +7,10 @@ export interface Assessment {
 }
 
 export interface Course {
+  code: string;
+  number: string;
+  title: string;
+  key: string;
   topic: string;
   assessments: Assessment[];
 }

--- a/client/src/logic/icsGen.ts
+++ b/client/src/logic/icsGen.ts
@@ -3,36 +3,37 @@ import { createEvents, EventAttributes } from "ics";
 export interface Assessment {
   name: string;
   date: string;
+  dateFormatted: string;
   weight: string;
 }
 
 export interface Course {
   code: string;
-  number: string;
+  number: number;
   title: string;
   key: string;
   topic: string;
   assessments: Assessment[];
 }
 
-export interface Courses {
-  [key: string]: Course;
+export interface Courses extends Array<Course> {
+  [index: number]: Course;
 }
 
-function jsonToICS(data: Courses): string {
+function jsonToICS(courses: Courses): string {
   const events: EventAttributes[] = [];
-  Object.entries(data).forEach(([course, courseData]) => {
-    for (const assessment of courseData.assessments) {
+
+  for (const course of courses) {
+    for (const assessment of course.assessments) {
       if (!assessment.date) {
         continue;
       }
       const [date, time] = assessment.date.split("T");
       const [year, month, day] = date.split("-");
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const [hours, minutes, milis] = time.split(":");
+      const [hours, minutes, ] = time.split(":");
 
       events.push({
-        title: `${course} ${assessment.name} (${assessment.weight}%)`,
+        title: `${course.code} ${course.number} - ${assessment.name} (${assessment.weight}%)`,
         start: [
           parseInt(year),
           parseInt(month),
@@ -43,12 +44,9 @@ function jsonToICS(data: Courses): string {
         duration: { hours: 0, minutes: 0, seconds: 0 },
       });
     }
-  });
-
-  const { error, value } = createEvents(events);
-  if (error) {
-    return "error";
   }
+
+  const { value } = createEvents(events);
   if (value) {
     return value;
   }

--- a/client/src/logic/icsGen.ts
+++ b/client/src/logic/icsGen.ts
@@ -3,7 +3,6 @@ import { createEvents, EventAttributes } from "ics";
 export interface Assessment {
   name: string;
   date: string;
-  dateFormatted: string;
   weight: string;
 }
 

--- a/client/src/pages/Review/Review.tsx
+++ b/client/src/pages/Review/Review.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo } from "react";
 import { useParams, Link, useNavigate } from "react-router-dom";
 import NavigationDrawer from "../../components/NavigationDrawer";
 import AssessmentCard from "../../components/AssessmentCard";
-import { classnames, formatDate } from "../../Utilities";
+import { classnames } from "../../Utilities";
 import { Course, Courses } from "../../logic/icsGen";
 import styles from "./Review.module.css";
 
@@ -17,43 +17,36 @@ const testState: Courses = [
       {
         name: "Identity Assignment",
         date: "2021-10-21T18:00:00.000",
-        dateFormatted: "October 21, 2021 at 18:00",
         weight: "6%",
       },
       {
         name: "Coping Profile Assignment",
         date: "2021-10-29T18:00:00.000",
-        dateFormatted: "October 29, 2021 at 18:00",
         weight: "2%",
       },
       {
         name: "Self-Reflection/Goal Setting Assignment",
         date: "2021-12-07T18:00:00.000",
-        dateFormatted: "December 7, 2021 at 18:00",
         weight: "7%",
       },
       {
         name: "Experiential-Learning/Article-Evaluation Course Component",
         date: "2021-12-08T23:59:59.999",
-        dateFormatted: "December 8, 2021 at 23:59",
         weight: "4%",
       },
       {
         name: "Exam 1",
         date: "2021-10-14T00:00:00.000",
-        dateFormatted: "October 14, 2021 at 00:00",
         weight: "25%",
       },
       {
         name: "Exam 2",
         date: "2021-11-18T00:00:00.000",
-        dateFormatted: "November 18, 2021 at 00:00",
         weight: "25%",
       },
       {
         name: "Exam 3/Final Exam",
         date: "",
-        dateFormatted: "",
         weight: "31%",
       },
     ],

--- a/client/src/pages/Review/Review.tsx
+++ b/client/src/pages/Review/Review.tsx
@@ -1,9 +1,11 @@
 import { useState, useEffect, useMemo } from "react";
-import { useParams, Link } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import NavigationDrawer from "../../components/NavigationDrawer";
 import AssessmentCard from "../../components/AssessmentCard";
 import { classnames } from "../../Utilities";
 import { Course, Courses } from "../../logic/icsGen";
+import Button from "../../components/Button";
+
 import styles from "./Review.module.css";
 
 const testState: Courses = [
@@ -113,9 +115,14 @@ const Review = () => {
     [currentCourseKey, courseKeyLookup[currentCourseKey || ""]]
   );
 
-  const onCourseClick = (course: Course) => {
-    setCurrentCourseKey(course.key);
-    setTimeout(() => history.pushState(null, "", `/app/${course.key}`), 100);
+  const onCourseClick = (course: Course | null) => {
+    if (course === null) {
+      setCurrentCourseKey(null);
+      setTimeout(() => history.pushState(null, "", "/app"), 10);
+    } else {
+      setCurrentCourseKey(course.key);
+      setTimeout(() => history.pushState(null, "", `/app/${course.key}`), 100);
+    }
   };
 
   return (
@@ -145,14 +152,14 @@ const Review = () => {
           )}
         >
           <header className="bg-gray-300 w-full p-4 text-xl">
-            <Link to="/app">
+            <Button onClick={() => onCourseClick(null)}>
               <span
                 className={classnames("material-icons", "md:hidden", "inline")}
                 style={{ fontSize: "1.5rem", verticalAlign: "middle" }}
               >
                 arrow_back
               </span>
-            </Link>
+            </Button>
             <h1 className="text-4xl">
               {currentCourse.title} {currentCourse.number}
             </h1>

--- a/client/src/pages/Review/Review.tsx
+++ b/client/src/pages/Review/Review.tsx
@@ -112,17 +112,19 @@ const Review = () => {
           <div className="flex flex-col md:flex-row">
             <div className="w-full md:hidden flex flex-row">
               <button
-                className={`w-full bg-gray-300 p-2 ${
+                className={classnames(
+                  "w-full bg-gray-300 p-2",
                   selectedTab === 0 && "bg-red-500"
-                }`}
+                )}
                 onClick={() => setSelectedTab(0)}
               >
                 Assessments
               </button>
               <button
-                className={`w-full bg-gray-300 p-2 ${
+                className={classnames(
+                  "w-full bg-gray-300 p-2",
                   selectedTab === 1 && "bg-red-500"
-                }`}
+                )}
                 onClick={() => setSelectedTab(1)}
               >
                 Document

--- a/client/src/pages/Review/Review.tsx
+++ b/client/src/pages/Review/Review.tsx
@@ -80,6 +80,7 @@ const Review = () => {
   
   // Callback for when the courses are changed
   const onCoursesChanged = (newCourses: Courses) => {
+    const existingCourseKeys = courses.map((course) => course.key);
     for (const course of newCourses) {
       // Numbering undetermined courses
       if (!course.code || !course.number) {
@@ -88,10 +89,13 @@ const Review = () => {
         course.title = "Course";
       }
 
-      // Generate the unique course key
+      // Generate course key
       const key = `${course.code}-${course.number}`.toLowerCase();
+      if (existingCourseKeys.includes(key)) continue;
+
       course.key = key;
       courses.push(course);
+      existingCourseKeys.push(key);
     }
 
     setCourses([...courses]);

--- a/client/src/pages/Review/Review.tsx
+++ b/client/src/pages/Review/Review.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from "react";
-import { useParams, Link, useNavigate } from "react-router-dom";
+import { useParams, Link } from "react-router-dom";
 import NavigationDrawer from "../../components/NavigationDrawer";
 import AssessmentCard from "../../components/AssessmentCard";
 import { classnames } from "../../Utilities";
@@ -60,12 +60,22 @@ enum Tab {
 }
 
 const Review = () => {
+  const { courseKey: courseKeyUrlParam } = useParams();
+
   const [selectedTab, setSelectedTab] = useState<Tab>(Tab.Assessments);
   const [courses, setCourses] = useState<Courses>(testState);
+  const [currentCourseKey, setCurrentCourseKey] = useState<string | null>(null);
 
-  const { courseKey: currentCourseKey } = useParams();
-  const navigate = useNavigate();
-
+  // At first render of the page, check if the course key is valid 
+  // and assign value to current course key
+  useEffect(() => {
+    if (courseKeyUrlParam === undefined || courseKeyLookup[courseKeyUrlParam] === undefined) {
+      setCurrentCourseKey(null);
+    } else {
+      setCurrentCourseKey(courseKeyUrlParam);
+    }
+  }, []);
+  
   // Callback for when the courses are changed
   const onCoursesChanged = (newCourses: Courses) => {
     for (const course of newCourses) {
@@ -103,12 +113,10 @@ const Review = () => {
     [currentCourseKey, courseKeyLookup[currentCourseKey || ""]]
   );
 
-  // Redirect to the app page if the course key is invalid
-  useEffect(() => {
-    if (!currentCourseKey || courseKeyLookup[currentCourseKey] === undefined) {
-      navigate("/app");
-    }
-  }, [currentCourseKey]);
+  const onCourseClick = (course: Course) => {
+    setCurrentCourseKey(course.key);
+    setTimeout(() => history.pushState(null, "", `/app/${course.key}`), 100);
+  };
 
   return (
     <div className="flex flex-row justify-between">
@@ -126,6 +134,7 @@ const Review = () => {
           courses={courses}
           currentCourseKey={currentCourseKey}
           onCoursesChanged={onCoursesChanged}
+          onCourseClick={onCourseClick}
         />
       </nav>
       {currentCourse && (

--- a/client/src/pages/Review/Review.tsx
+++ b/client/src/pages/Review/Review.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { useParams, Link } from "react-router-dom";
+import { useState, useEffect } from "react";
+import { useParams, Link, useNavigate } from "react-router-dom";
 import NavigationDrawer from "../../components/NavigationDrawer";
 import AssessmentCard from "../../components/AssessmentCard";
 import { classnames } from "../../Utilities";
@@ -7,7 +7,11 @@ import { Courses } from "../../logic/icsGen";
 import styles from "./Review.module.css";
 
 const testState: Courses = {
-  "PSYC 203": {
+  "psyc-203": {
+    code: "PYSC",
+    number: "203",
+    title: "Psychology",
+    key: "psyc-203",
     topic: "Psychology of Everyday Life",
     assessments: [
       {
@@ -52,26 +56,47 @@ const testState: Courses = {
 const Review = () => {
   const [selectedTab, setSelectedTab] = useState(0);
   const [courses, setCourses] = useState<Courses>(testState);
-  const displayFormat = (course: string) => course.replace(/-/g, " ").toUpperCase();
 
-  let { courseId } = useParams();
-  courseId = courseId ? displayFormat(courseId) : undefined;
+  const { courseKey } = useParams();
+  const navigate = useNavigate();
 
   const onCoursesChanged = (newCourses: Courses) => {
     setCourses({ ...courses, ...newCourses });
   };
 
+  useEffect(() => {
+    if (!courseKey || courses[courseKey] === undefined) {
+      navigate("/app");
+    }
+  }, [courseKey]);
+
   return (
     <div className="flex flex-row justify-between">
       <nav
-        className={classnames("md:w-64", "w-full", "flex-shrink-0", courseId && "hidden", "md:block", "bg-gray-100")}
+        className={classnames(
+          "md:w-64",
+          "w-full",
+          "flex-shrink-0",
+          courseKey && "hidden",
+          "md:block",
+          "bg-gray-100"
+        )}
       >
-        <NavigationDrawer courses={courses} currentCourseKeyString={courseId} onCoursesChanged={onCoursesChanged} />
+        <NavigationDrawer
+          courses={courses}
+          currentCourseKeyString={courseKey}
+          onCoursesChanged={onCoursesChanged}
+        />
       </nav>
-      {courseId && (
-        <main className={classnames("flex-shrink-0 text-center w-full", styles.main)}>
+      {courseKey && courses[courseKey] && (
+        <main
+          className={classnames(
+            "flex-shrink-0 text-center w-full",
+            styles.main
+          )}
+        >
           <header className="bg-gray-300 w-full p-4 text-xl">
-            <Link to="/review">
+            <Link to="/app">
               <span
                 className={classnames("material-icons", "md:hidden", "inline")}
                 style={{ fontSize: "1.5rem", verticalAlign: "middle" }}
@@ -79,19 +104,25 @@ const Review = () => {
                 arrow_back
               </span>
             </Link>
-            <h1 className="text-4xl">{courseId && displayFormat(courseId)}</h1>
-            <h2 className="text-2xl">{courses[courseId]?.topic}</h2>
+            <h1 className="text-4xl">
+              {courses[courseKey].title} {courses[courseKey].number}
+            </h1>
+            <h2 className="text-2xl">{courses[courseKey].topic}</h2>
           </header>
           <div className="flex flex-col md:flex-row">
             <div className="w-full md:hidden flex flex-row">
               <button
-                className={`w-full bg-gray-300 p-2 ${selectedTab === 0 && "bg-red-500"}`}
+                className={`w-full bg-gray-300 p-2 ${
+                  selectedTab === 0 && "bg-red-500"
+                }`}
                 onClick={() => setSelectedTab(0)}
               >
                 Assessments
               </button>
               <button
-                className={`w-full bg-gray-300 p-2 ${selectedTab === 1 && "bg-red-500"}`}
+                className={`w-full bg-gray-300 p-2 ${
+                  selectedTab === 1 && "bg-red-500"
+                }`}
                 onClick={() => setSelectedTab(1)}
               >
                 Document
@@ -108,7 +139,7 @@ const Review = () => {
               )}
             >
               <ul className="flex flex-col">
-                {courses[courseId]?.assessments.map((assessment) => (
+                {courses[courseKey].assessments.map((assessment) => (
                   <AssessmentCard
                     key={assessment.name + assessment.date + assessment.weight} // should be assessment.source eventually
                     assessment={assessment}

--- a/client/src/pages/Review/Review.tsx
+++ b/client/src/pages/Review/Review.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useParams, Link, useNavigate } from "react-router-dom";
 import NavigationDrawer from "../../components/NavigationDrawer";
 import AssessmentCard from "../../components/AssessmentCard";
@@ -56,7 +56,7 @@ const testState: Courses = {
 // Enum for the tabs
 enum Tab {
   Assessments,
-  Document
+  Document,
 }
 
 const Review = () => {
@@ -69,6 +69,11 @@ const Review = () => {
   const onCoursesChanged = (newCourses: Courses) => {
     setCourses({ ...courses, ...newCourses });
   };
+
+  const course = useMemo(
+    () => (courseKey && courseKey in courses ? courses[courseKey] : null),
+    [courseKey, courses[courseKey || 0]]
+  );
 
   useEffect(() => {
     if (!courseKey || courses[courseKey] === undefined) {
@@ -94,7 +99,7 @@ const Review = () => {
           onCoursesChanged={onCoursesChanged}
         />
       </nav>
-      {courseKey && courses[courseKey] && (
+      {course && (
         <main
           className={classnames(
             "flex-shrink-0 text-center w-full",
@@ -111,9 +116,9 @@ const Review = () => {
               </span>
             </Link>
             <h1 className="text-4xl">
-              {courses[courseKey].title} {courses[courseKey].number}
+              {course.title} {course.number}
             </h1>
-            <h2 className="text-2xl">{courses[courseKey].topic}</h2>
+            <h2 className="text-2xl">{course.topic}</h2>
           </header>
           <div className="flex flex-col md:flex-row">
             <div className="w-full md:hidden flex flex-row">
@@ -147,7 +152,7 @@ const Review = () => {
               )}
             >
               <ul className="flex flex-col">
-                {courses[courseKey].assessments.map((assessment) => (
+                {course.assessments.map((assessment) => (
                   <AssessmentCard
                     key={assessment.name + assessment.date + assessment.weight} // should be assessment.source eventually
                     assessment={assessment}

--- a/client/src/pages/Review/Review.tsx
+++ b/client/src/pages/Review/Review.tsx
@@ -132,7 +132,7 @@ const Review = () => {
       >
         <NavigationDrawer
           courses={courses}
-          currentCourseKey={currentCourseKey}
+          currentCourse={currentCourse}
           onCoursesChanged={onCoursesChanged}
           onCourseClick={onCourseClick}
         />

--- a/client/src/pages/Review/Review.tsx
+++ b/client/src/pages/Review/Review.tsx
@@ -86,12 +86,6 @@ const Review = () => {
       // Generate the unique course key
       const key = `${course.code}-${course.number}`.toLowerCase();
       course.key = key;
-
-      // Cache the formatted dates
-      for (const assessment of course.assessments) {
-        assessment.dateFormatted = formatDate(assessment.date) || "";
-      }
-
       courses.push(course);
     }
 
@@ -194,9 +188,9 @@ const Review = () => {
               )}
             >
               <ul className="flex flex-col">
-                {course.assessments.map((assessment) => (
+                {course.assessments.map((assessment, t) => (
                   <AssessmentCard
-                    key={assessment.name + assessment.date + assessment.weight} // should be assessment.source eventually
+                    key={t}
                     assessment={assessment}
                     onAssessmentClick={() => {
                       console.log("clicked");

--- a/client/src/pages/Review/Review.tsx
+++ b/client/src/pages/Review/Review.tsx
@@ -53,8 +53,14 @@ const testState: Courses = {
   },
 };
 
+// Enum for the tabs
+enum Tab {
+  Assessments,
+  Document
+}
+
 const Review = () => {
-  const [selectedTab, setSelectedTab] = useState(0);
+  const [selectedTab, setSelectedTab] = useState<Tab>(Tab.Assessments);
   const [courses, setCourses] = useState<Courses>(testState);
 
   const { courseKey } = useParams();
@@ -114,7 +120,7 @@ const Review = () => {
               <button
                 className={classnames(
                   "w-full bg-gray-300 p-2",
-                  selectedTab === 0 && "bg-red-500"
+                  selectedTab === Tab.Assessments && "bg-red-500"
                 )}
                 onClick={() => setSelectedTab(0)}
               >
@@ -123,7 +129,7 @@ const Review = () => {
               <button
                 className={classnames(
                   "w-full bg-gray-300 p-2",
-                  selectedTab === 1 && "bg-red-500"
+                  selectedTab === Tab.Document && "bg-red-500"
                 )}
                 onClick={() => setSelectedTab(1)}
               >
@@ -137,7 +143,7 @@ const Review = () => {
                 "border",
                 "p-4",
                 "h-screen",
-                selectedTab === 1 && "hidden md:block"
+                selectedTab === Tab.Document && "hidden md:block"
               )}
             >
               <ul className="flex flex-col">
@@ -161,7 +167,7 @@ const Review = () => {
                 "bg-gray-200",
                 "p-4",
                 "h-screen",
-                selectedTab === 0 && "hidden md:block"
+                selectedTab === Tab.Assessments && "hidden md:block"
               )}
             >
               <img src="../pdf.png" alt="the pdf viewer" />

--- a/client/src/pages/Review/Review.tsx
+++ b/client/src/pages/Review/Review.tsx
@@ -63,7 +63,7 @@ const Review = () => {
   const [selectedTab, setSelectedTab] = useState<Tab>(Tab.Assessments);
   const [courses, setCourses] = useState<Courses>(testState);
 
-  const { courseKey } = useParams();
+  const { courseKey: currentCourseKey } = useParams();
   const navigate = useNavigate();
 
   // Callback for when the courses are changed
@@ -95,20 +95,20 @@ const Review = () => {
   );
 
   // Memoize the course based on the course key
-  const course = useMemo(
+  const currentCourse = useMemo(
     () =>
-      courseKey && courseKey in courseKeyLookup
-        ? courseKeyLookup[courseKey]
+      currentCourseKey && currentCourseKey in courseKeyLookup
+        ? courseKeyLookup[currentCourseKey]
         : null,
-    [courseKey, courseKeyLookup[courseKey || ""]]
+    [currentCourseKey, courseKeyLookup[currentCourseKey || ""]]
   );
 
   // Redirect to the app page if the course key is invalid
   useEffect(() => {
-    if (!courseKey || courseKeyLookup[courseKey] === undefined) {
+    if (!currentCourseKey || courseKeyLookup[currentCourseKey] === undefined) {
       navigate("/app");
     }
-  }, [courseKey]);
+  }, [currentCourseKey]);
 
   return (
     <div className="flex flex-row justify-between">
@@ -117,18 +117,18 @@ const Review = () => {
           "md:w-64",
           "w-full",
           "flex-shrink-0",
-          courseKey && "hidden",
+          currentCourseKey && "hidden",
           "md:block",
           "bg-gray-100"
         )}
       >
         <NavigationDrawer
           courses={courses}
-          currentCourseKey={courseKey}
+          currentCourseKey={currentCourseKey}
           onCoursesChanged={onCoursesChanged}
         />
       </nav>
-      {course && (
+      {currentCourse && (
         <main
           className={classnames(
             "flex-shrink-0 text-center w-full",
@@ -145,9 +145,9 @@ const Review = () => {
               </span>
             </Link>
             <h1 className="text-4xl">
-              {course.title} {course.number}
+              {currentCourse.title} {currentCourse.number}
             </h1>
-            <h2 className="text-2xl">{course.topic}</h2>
+            <h2 className="text-2xl">{currentCourse.topic}</h2>
           </header>
           <div className="flex flex-col md:flex-row">
             <div className="w-full md:hidden flex flex-row">
@@ -181,7 +181,7 @@ const Review = () => {
               )}
             >
               <ul className="flex flex-col">
-                {course.assessments.map((assessment, t) => (
+                {currentCourse.assessments.map((assessment, t) => (
                   <AssessmentCard
                     key={t}
                     assessment={assessment}

--- a/server/handlers/file_handler.py
+++ b/server/handlers/file_handler.py
@@ -202,15 +202,4 @@ def handle_files(files: List[UploadFile]):
         finally:
             tmp_path.unlink()
 
-    results = {}
-    for index, course in enumerate(courses):
-
-        if not course["code"] or not course["number"]:
-            course["code"] = "Course"
-            course["number"] = index + 1
-            course["title"] = "Course"
-
-        key = f"{course['code']}-{course['number']}".lower()
-        course["key"] = key
-        results[key] = course
-    return results
+    return courses

--- a/server/test-data/CPSC331/expected.json
+++ b/server/test-data/CPSC331/expected.json
@@ -1,15 +1,16 @@
-{
-  "cpsc-331": {
-    "cid": 3628,
+[
+  {
     "code": "CPSC",
     "number": 331,
-    "key": "cpsc-331",
+    "cid": 3628,
     "topic": "Data Structures, Algorithms, and Their Analysis",
     "description": "Fundamental data structures, including arrays, lists, stacks, queues, trees, hash tables, and graphs. Algorithms for searching and sorting. Introduction to the correctness and analysis of algorithms. For computer science majors and those interested in algorithm design and analysis, information security, and other mathematically-intensive areas.",
     "sub_topics": null,
     "units": 3.0,
     "credits": null,
-    "hours": ["3-2T"],
+    "hours": [
+      "3-2T"
+    ],
     "time_length": null,
     "prereq": "3 units from <course cid=\"44642\">Computer Science 251</course>, <course cid=\"6947\">Mathematics 271</course> or <course cid=\"6948\">273</course>; and 3 units from <course cid=\"3620\">Computer Science 219</course>, <course cid=\"3622\">233</course>, <course cid=\"3623\">235</course>, <course cid=\"43065\">Computer Engineering 335</course>, 339 or <course cid=\"43066\">Software Engineering for Engineers 337</course>.",
     "coreq": null,
@@ -28,8 +29,12 @@
         "+1 (403) 282-9154 (Fax)",
         "+1 (403) 220-8600 (Undergraduate Science Centre)"
       ],
-      "rooms": ["Biological Sciences 540"],
-      "email": ["scidean@ucalgary.ca"],
+      "rooms": [
+        "Biological Sciences 540"
+      ],
+      "email": [
+        "scidean@ucalgary.ca"
+      ],
       "website": [
         "http://science.ucalgary.ca/",
         "http://science.ucalgary.ca/usc"
@@ -93,4 +98,4 @@
       }
     ]
   }
-}
+]

--- a/server/test-data/CPSC331/expected.json
+++ b/server/test-data/CPSC331/expected.json
@@ -1,8 +1,9 @@
 {
-  "CPSC 331": {
+  "cpsc-331": {
     "cid": 3628,
     "code": "CPSC",
     "number": 331,
+    "key": "cpsc-331",
     "topic": "Data Structures, Algorithms, and Their Analysis",
     "description": "Fundamental data structures, including arrays, lists, stacks, queues, trees, hash tables, and graphs. Algorithms for searching and sorting. Introduction to the correctness and analysis of algorithms. For computer science majors and those interested in algorithm design and analysis, information security, and other mathematically-intensive areas.",
     "sub_topics": null,


### PR DESCRIPTION
This PR is branched off from #117 and fixes issues in that PR, so please merge #117 before this one.
This PR also includes several refactorings.


### Changes
- Move _response data_ processing logic from `NavigationDrawer` to `Review` for low-coupling
- Refactor `courseKey` in url params and relative page switching
- Extending `Courses` interface from `Array<Course>` (equivalent to `Course[]`, an array of `Course` objects), since `Review` seems to be the only place that needs to have a "lookup table" in the format of `{ [courseKey]: Course }` for quick access, `NavigationDrawer` and `icsGen` works perfectly well with an array, so components (and between FE and BE) are passing an __array__ of `Course` now
- Introduce `courseKeyLookup: Record<string, Course>` dictionary for quick access in `Review`, with `useMemo` it is cached and re-calculate whenever `courses` changes
- Introduce `currentCourse: Course` as the current selected course for performance, with `useMemo` it is cached and re-calculate whever `currentCourseKey` or content in `courseKeyLookup[currentCourseKey]` changes


### Future notes
`Review` is getting longer and longer and that makes sense as it contains all the hook-up logics, and to not burying hook-up logics deep down in relative sub-components. When it gets too long, we could move callback functions to a file such as `hooks.ts` and have ReactNodes in a separate file such as `ReviewView.tsx`.

For-loops requires a `key` to all children. Make life easier to not come up with unique keys, here's a trick:
```js
array.map((element, index) => (<Component key={index} />));
```