### PR TITLE
Fixes 404s With GH Pages (hopefully)

### DIFF
--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { Routes, Route, BrowserRouter } from "react-router-dom";
+import { Routes, Route, HashRouter } from "react-router-dom";
 import axios from "axios";
 import "./index.css";
 
@@ -27,7 +27,7 @@ axios.defaults.timeout = 30000;
 function App() {
   return (
     <>
-      <BrowserRouter>
+      <HashRouter>
         <Routes>
           <Route path="/" element={<Landing />} />
           <Route path="/landing" element={<Landing />} />
@@ -36,7 +36,7 @@ function App() {
           <Route path="/app/:courseKey" element={<Review />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
-      </BrowserRouter>
+      </HashRouter>
     </>
   );
 }

--- a/client/src/pages/Review/Review.tsx
+++ b/client/src/pages/Review/Review.tsx
@@ -137,10 +137,10 @@ const Review = () => {
   const onCourseClick = (course: Course | null) => {
     if (course === null) {
       setCurrentCourseKey(null);
-      setTimeout(() => history.pushState(null, "", "/app"), 10);
+      setTimeout(() => history.pushState(null, "", "/#/app"), 10);
     } else {
       setCurrentCourseKey(course.key);
-      setTimeout(() => history.pushState(null, "", `/app/${course.key}`), 100);
+      setTimeout(() => history.pushState(null, "", `/#/app/${course.key}`), 100);
     }
   };
 


### PR DESCRIPTION
Followed https://www.freecodecamp.org/news/deploy-a-react-app-to-github-pages/ and used HashRouter instead of BrowserRouter.
Now all routes are behind a /#/ but it works as far as I can tell. I tested this by building and serving with `python -m http.server 80`. Before the change, I got 404s when refreshing. After the change, it works, and I get the NotFound page when I got to a non existent route.
Closes #64