### PR TITLE
Server test for bad files

### DIFF
--- a/server/src/test_app.py
+++ b/server/src/test_app.py
@@ -1,4 +1,4 @@
-"""Tests for the server. Run with `pytest test_app.py -s` to see print statements`"""
+"""Tests for the server. Run with `pytest test_app.py -s` to see print statements"""
 
 import json
 from fastapi.testclient import TestClient
@@ -42,3 +42,21 @@ def test_one_expected_outline():
 
     assert response.status_code == 200
     assert response.json() == expected_response
+
+
+def test_bad_file():
+    """Sends a bad file to the endpoint and checks that the response is correct"""
+    with open("./app.py", "rb") as file:  # not a pdf
+        request_data = {"outline_file": ("app.pdf", file, "application/pdf")}
+        response = client.post("/files", files=request_data)
+
+    assert response.status_code == 422
+
+
+def future_test_too_large_file():
+    """Sends a file that is too large to the endpoint and checks that the response is correct"""
+    with open("../test-data/too-large.pdf", "rb") as file:
+        request_data = {"outline_file": ("CPSC331.pdf", file, "application/pdf")}
+        response = client.post("/files", files=request_data)
+
+    assert response.status_code == 413

--- a/server/test-data/too-large.pdf
+++ b/server/test-data/too-large.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:90b9b8914715456fd1a495385843cf73ce8634d11c03050ac167af3f20970900
+size 167756


### PR DESCRIPTION
`def future_test_too_large_file():` will not run since it does not have the prefix `test_` in it's signature. It can be made into a real test with the closure of #145 