### PR TITLE
110 implement frontend data persistence

### DIFF
--- a/client/src/logic/icsGen.ts
+++ b/client/src/logic/icsGen.ts
@@ -16,6 +16,32 @@ export interface Course {
   assessments: Assessment[];
 }
 
+// rawCourse is the JSON object from the server or from local storage, so Dates and Numbers are strings
+export function parseCourse(rawCourse: {
+  code: string;
+  number: string;
+  title: string;
+  key: string;
+  topic: string;
+  assessments: { name: string; date: string; weight: string }[];
+}): Course {
+  const course: Course = {
+    ...rawCourse,
+    number: Number(rawCourse.number),
+    assessments: rawCourse.assessments.map(
+      (a: { name: string; date: string; weight: string }) => {
+        return {
+          name: a.name,
+          date: new Date(a.date),
+          weight: Number(a.weight),
+        } as Assessment;
+      }
+    ),
+  };
+
+  return course;
+}
+
 export interface Courses extends Array<Course> {
   [index: number]: Course;
 }

--- a/client/src/pages/Review/NavigationPanel.tsx
+++ b/client/src/pages/Review/NavigationPanel.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from "react";
 import List from "../../components/List";
 import NavigationDrawer from "../../components/NavigationDrawer";
-import jsonToICS, { Course, Courses } from "../../logic/icsGen";
+import jsonToICS, { Course, Courses, parseCourse } from "../../logic/icsGen";
 import axios from "axios";
 import { classnames } from "../../Utilities";
 import ProgressIndicator from "../../components/ProgressIndicator";
@@ -50,16 +50,7 @@ const NavigationPanel = ({
         .then((res) => res.data)
         .then((data) => {
           // convert to Course
-          const course: Course = {
-            ...data,
-            assessments: data.assessments.map(
-              (a: { name: string; date: string; weight: string }) => ({
-                ...a,
-                date: new Date(a.date),
-                weight: Number(a.weight),
-              })
-            ),
-          };
+          const course: Course = parseCourse(data);
           course.code = course.code || "Course";
           course.number = course.number || courses.length + 1;
           course.title = course.title || course.code;

--- a/client/src/pages/Review/Review.tsx
+++ b/client/src/pages/Review/Review.tsx
@@ -8,7 +8,7 @@ import {
 import { useBeforeUnload, useParams } from "react-router-dom";
 
 import { classnames } from "../../Utilities";
-import { Assessment, Course, Courses } from "../../logic/icsGen";
+import { Assessment, Course, Courses, parseCourse } from "../../logic/icsGen";
 
 import { IconButton } from "../../components/Button";
 import AppTopBar, {
@@ -71,7 +71,7 @@ const Review = () => {
     const foundCourses = localStorage.getItem("courses");
     if (!foundCourses) return;
 
-    const parsedCourses: Courses = JSON.parse(foundCourses);
+    const parsedCourses: Courses = JSON.parse(foundCourses).map(parseCourse);
     setCourses(parsedCourses);
     coursesRef.current = parsedCourses;
 


### PR DESCRIPTION
Uses the `useBeforeUnload` hook from react router to cache the `courses` into localstorage when the window is closed/refreshed, and attempts to retrieve it upon loading.

Also made a function `parseCourse` in `icsGen.ts` that casts raw JSON object to `Courses` type. Used for localstorage retrieval and server response parsing. I'm not sure if there's a better way to do this, probably is