### PR TITLE
(Incomplete) 210 history bug at app

### DIFF
--- a/client/src/components/CourseInfo/CourseInfo.tsx
+++ b/client/src/components/CourseInfo/CourseInfo.tsx
@@ -67,7 +67,6 @@ const Description = ({ text }: { text: string }) => {
     paragraphRef.current.classList.add("line-clamp-3");
     const clampedHeight = paragraphRef.current.clientHeight;
     setClampable(originalHeight !== clampedHeight);
-    console.log(originalHeight, clampedHeight);
   }, [text, paragraphRef.current, width]);
 
   return (

--- a/client/src/pages/Review/NavigationPanel.tsx
+++ b/client/src/pages/Review/NavigationPanel.tsx
@@ -60,6 +60,7 @@ const NavigationPanel = ({
         })
         .catch((error) => {
           console.log(error);
+          // Trigger snackbar here
         })
         .finally(() => {
           setLoading((prev) => prev.filter((f) => f !== file?.name));

--- a/client/src/pages/Review/Review.tsx
+++ b/client/src/pages/Review/Review.tsx
@@ -95,20 +95,18 @@ const Review = () => {
 
   useEffect(recoverCourses, []);
 
-  window.addEventListener("popstate", (event) => {
-    cacheCourses();
-  });
+  window.addEventListener("popstate", cacheCourses);
 
   useBeforeUnload(useCallback(cacheCourses, [courses]));
 
-  useEffect(() => {
-    // Update history when current course changes
-    if (currentCourse === null) {
-      history.pushState(null, "", "/app");
-    } else {
-      history.pushState(null, "", `/app/${currentCourse.key}`);
-    }
-  }, [currentCourse]);
+  // useEffect(() => {
+  //   // Update history when current course changes
+  //   if (currentCourse === null) {
+  //     history.pushState(null, "", "/app");
+  //   } else {
+  //     history.pushState(null, "", `/app/${currentCourse.key}`);
+  //   }
+  // }, [currentCourse]);
 
   // Callback for select course in navigation drawer
   const onCourseClick = (course: Course) => {

--- a/client/src/pages/Review/Review.tsx
+++ b/client/src/pages/Review/Review.tsx
@@ -95,18 +95,24 @@ const Review = () => {
 
   useEffect(recoverCourses, []);
 
-  window.addEventListener("popstate", cacheCourses);
+  useEffect(() => {
+    // Cache courses when user navigates away
+    window.addEventListener("popstate", cacheCourses);
+    return () => {
+      window.removeEventListener("popstate", cacheCourses);
+    };
+  }, []);
 
   useBeforeUnload(useCallback(cacheCourses, [courses]));
 
-  // useEffect(() => {
-  //   // Update history when current course changes
-  //   if (currentCourse === null) {
-  //     history.pushState(null, "", "/app");
-  //   } else {
-  //     history.pushState(null, "", `/app/${currentCourse.key}`);
-  //   }
-  // }, [currentCourse]);
+  useEffect(() => {
+    // Update history when current course changes
+    if (currentCourse === null) {
+      history.pushState(null, "", "/app");
+    } else {
+      history.pushState(null, "", `/app/${currentCourse.key}`);
+    }
+  }, [currentCourse]);
 
   // Callback for select course in navigation drawer
   const onCourseClick = (course: Course) => {

--- a/client/src/pages/Review/Review.tsx
+++ b/client/src/pages/Review/Review.tsx
@@ -29,12 +29,10 @@ const Review = () => {
   }>();
 
   const cacheCourses = () => {
-    console.log("Caching courses");
     localStorage.setItem("courses", JSON.stringify(coursesRef.current));
   };
 
   const recoverCourses = () => {
-    console.log("Recovering courses");
     // Load courses from local storage
     const foundCourses = localStorage.getItem("courses");
     if (!foundCourses) return;


### PR DESCRIPTION
I've been trying for too long and haven't been able to fix this bug. But I did make a fix that caches the courses on popstate, when the user clicks back on the browser. Previously this would result in losing any changes. 

I noticed that the behavior is slightly different in dev vs production for this bug. In prod, if you click "Get Started" you need to click back twice to get back to the landing page. In dev, it's 3 times. Maybe the best solution is to manually pop one `/app` off of history when the page loads, but I don't know how to do that.

Time for someone else to give this a go.