### PR TITLE
Rename Server Entry Point

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -6,4 +6,4 @@ RUN  pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}" -U --no-cac
 
 COPY ./src ${LAMBDA_TASK_ROOT}
 
-CMD [ "app.handler" ]
+CMD [ "main.handler" ]

--- a/server/src/main.py
+++ b/server/src/main.py
@@ -1,13 +1,13 @@
-"""Entry point for the server"""
+"""Entry point for the server. You can run this file directly to start the server locally."""
 
 from os import environ
 from typing import List
+
 import uvicorn
-
 from fastapi import FastAPI, File, UploadFile, Response
-
 from fastapi.middleware.cors import CORSMiddleware
 from mangum import Mangum
+
 from handlers import calendar_handler, file_handler, xlsx_handler
 
 
@@ -20,7 +20,7 @@ app = FastAPI(
     docs_url="/docs" if not IS_IN_PROD else None,
     redoc_url="/redoc" if not IS_IN_PROD else None,
 )
-handler = Mangum(app)
+handler = Mangum(app)  # required for AWS Lambda
 
 
 origins = (
@@ -60,4 +60,4 @@ async def get_xlsx(semester: List[dict]):
 
 
 if __name__ == "__main__":
-    uvicorn.run("app:app", host="127.0.0.1", port=8000)
+    uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)

--- a/server/src/test_app.py
+++ b/server/src/test_app.py
@@ -4,7 +4,7 @@ import json
 from fastapi.testclient import TestClient
 from handlers import calendar_handler
 
-from server.src.main import app
+from main import app
 
 EXPECTEDCALENDARJSON = None
 with open("data/calendar.json", encoding="utf8") as stream:
@@ -46,7 +46,7 @@ def test_one_expected_outline():
 
 def test_bad_file():
     """Sends a bad file to the endpoint and checks that the response is correct"""
-    with open("./app.py", "rb") as file:  # not a pdf
+    with open("./data/course_codes.pkl", "rb") as file:  # not a pdf
         request_data = {"outline_file": ("app.pdf", file, "application/pdf")}
         response = client.post("/files", files=request_data)
 

--- a/server/src/test_app.py
+++ b/server/src/test_app.py
@@ -4,7 +4,7 @@ import json
 from fastapi.testclient import TestClient
 from handlers import calendar_handler
 
-from app import app
+from server.src.main import app
 
 EXPECTEDCALENDARJSON = None
 with open("data/calendar.json", encoding="utf8") as stream:


### PR DESCRIPTION
Main change is renaming the server entry point from `app.py` to `main.py` as this is what I see being convention. I would like to hear from @harsweet though if there was a reason to name it `app.py`.

Also changes the run command to reload on changes by default and broadcast to LAN (origins are still restricted for security on a public network)
https://github.com/techstartucalgary/lifeline/blob/5fd418f6d895e434d33fb5519bcdf5661224408e/server/src/main.py#L63