### PR TITLE
FE Refinement (5 / ∞): Window scroll listener performance bottleneck resolved on `AppTopBar`

### DIFF
--- a/client/src/components/AppTopBar/AppTopBar.tsx
+++ b/client/src/components/AppTopBar/AppTopBar.tsx
@@ -1,11 +1,4 @@
-import useScrollPosition from "@react-hook/window-scroll";
-import {
-  HTMLAttributes,
-  ReactElement,
-  useState,
-  useRef,
-  useLayoutEffect,
-} from "react";
+import { HTMLAttributes, ReactElement } from "react";
 
 import { classnames } from "../../Utilities";
 
@@ -14,12 +7,12 @@ import Headline from "./Headline";
 import {
   LeadingNavigation,
   LeadingNavigationProp,
-  TrailingIcon,
-  TrailingIconProp,
-  Title,
-  TitleProp,
   Subtitle,
   SubtitleProp,
+  Title,
+  TitleProp,
+  TrailingIcon,
+  TrailingIconProp,
 } from "./Subcomponents";
 
 interface AppTopBarProps extends HTMLAttributes<HTMLDivElement> {
@@ -59,68 +52,26 @@ const AppTopBar = ({
     (child) => child !== undefined && child.type === Subtitle
   );
 
-  // For scrolling
-  const scrollY = useScrollPosition(240);
-
-  // For compact title height
-  const compactHeadlineRef = useRef<HTMLDivElement>(null);
-  const headlineRef = useRef<HTMLDivElement>(null);
-  const [compactHeadlineHeight, setCompactHeadlineHeight] = useState(0);
-  const [headlineHeight, setHeadlineHeight] = useState(0);
-  useLayoutEffect(() => {
-    const onTopbarHeight = () => {
-      const chh = compactHeadlineRef.current?.offsetHeight || 0;
-      const hh = headlineRef.current?.offsetHeight || 0;
-      setCompactHeadlineHeight(chh);
-      setHeadlineHeight(hh);
-    };
-
-    onTopbarHeight();
-    window.addEventListener("resize", onTopbarHeight);
-    return () => window.removeEventListener("resize", onTopbarHeight);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [compactHeadlineRef.current, headlineRef.current]);
-
   return (
     <>
       <CompactHeadline
         {...args}
         title={title}
-        titleClassName={classnames(
-          "opacity-0",
-          (scrollY > compactHeadlineHeight * 0.75 || variant === "small") &&
-            "opacity-1"
-        )}
+        titleClassName={classnames(variant === "small" && "opacity-1")}
         leadingNavigation={leadingNavigation}
         trailingIcon={trailingIcon}
         elevation={elevation}
-        elevationClassName={classnames(
-          "opacity-0",
-          scrollY > headlineHeight && "opacity-1"
-        )}
-        ref={compactHeadlineRef}
       />
-      <div style={{ paddingTop: compactHeadlineHeight }}>
-        <Headline
-          {...args}
-          className={classnames(
-            variant === "small" && "h-0",
-            variant === "large" && "pt-6",
-            args.className
-          )}
-          title={title}
-          subtitle={subtitle}
-          titleClassName={classnames(
-            "opacity-1",
-            scrollY > compactHeadlineHeight * 0.75 && "opacity-0"
-          )}
-          subtitleClassName={classnames(
-            "opacity-1",
-            scrollY > compactHeadlineHeight * 0.75 && "opacity-0"
-          )}
-          ref={headlineRef}
-        />
-      </div>
+      <Headline
+        {...args}
+        className={classnames(
+          variant === "small" && "h-0",
+          variant === "large" && "pt-6",
+          args.className
+        )}
+        title={title}
+        subtitle={subtitle}
+      />
     </>
   );
 };
@@ -131,11 +82,11 @@ AppTopBar.Title = Title;
 AppTopBar.Subtitle = Subtitle;
 
 export default AppTopBar;
-export type { AppTopBarProps };
-export { LeadingNavigation, TrailingIcon, Title, Subtitle };
+export { LeadingNavigation, Subtitle, Title, TrailingIcon };
 export type {
+  AppTopBarProps,
   LeadingNavigationProp,
-  TrailingIconProp,
-  TitleProp,
   SubtitleProp,
+  TitleProp,
+  TrailingIconProp,
 };

--- a/client/src/components/AppTopBar/CompactHeadline.tsx
+++ b/client/src/components/AppTopBar/CompactHeadline.tsx
@@ -1,10 +1,16 @@
-import { ForwardedRef, HTMLAttributes, ReactElement, forwardRef } from "react";
+import useScrollPosition from "@react-hook/window-scroll";
+import { HTMLAttributes, ReactElement } from "react";
 
 import { classnames } from "../../Utilities";
 
-import { LeadingNavigationProp, TitleProp, TrailingIconProp } from "./Subcomponents";
+import {
+  LeadingNavigationProp,
+  TitleProp,
+  TrailingIconProp,
+} from "./Subcomponents";
 
-interface CompactHeadlineProp extends Omit<HTMLAttributes<HTMLDivElement>, "title"> {
+interface CompactHeadlineProp
+  extends Omit<HTMLAttributes<HTMLDivElement>, "title"> {
   title?: ReactElement<TitleProp>;
   titleClassName?: string | null;
   leadingNavigation?: ReactElement<LeadingNavigationProp>;
@@ -13,13 +19,23 @@ interface CompactHeadlineProp extends Omit<HTMLAttributes<HTMLDivElement>, "titl
   elevationClassName?: string | null;
 }
 
-const CompactHeadline = forwardRef<HTMLDivElement, CompactHeadlineProp>(
-  (
-    { title, titleClassName, leadingNavigation, trailingIcon, elevation = true, elevationClassName, ...args }: CompactHeadlineProp,
-    ref: ForwardedRef<HTMLDivElement>
-  ) => {
-    return (
-      <div className="fixed top-0 left-0 right-0 h-fit z-10" ref={ref}>
+const normalize = (val: number, min: number, max: number) =>
+  (val - min) / (max - min);
+
+const CompactHeadline = ({
+  title,
+  titleClassName,
+  leadingNavigation,
+  trailingIcon,
+  elevation = true,
+  elevationClassName,
+  ...args
+}: CompactHeadlineProp) => {
+  const scrollY = useScrollPosition(240);
+
+  return (
+    <>
+      <div className="fixed top-0 left-0 right-0 h-fit z-10 compact-headline">
         <div className="relative">
           <div {...args} className={classnames("bg-surface", args.className)}>
             <div className="flex flex-row px-1 pt-2 pb-1 justify-between">
@@ -30,39 +46,44 @@ const CompactHeadline = forwardRef<HTMLDivElement, CompactHeadlineProp>(
                 </div>
                 <div
                   className={classnames(
-                    "text-on-surface text-lg opacity-0 will-change-auto font-bold",
-                    "transition-opacity duration-300 ease-emphasized-decelerate opacity-0",
-                    titleClassName,
+                    "text-on-surface text-lg will-change-auto font-bold",
+                    "transition-opacity duration-200 md:duration-75",
+                    titleClassName
                   )}
+                  style={{
+                    opacity: normalize(scrollY, 40, 50),
+                  }}
                 >
                   {title}
                 </div>
               </div>
 
               {/* Trailing Icon */}
-              <div className="p-1 text-on-surface-variant">
-                {trailingIcon}
-              </div>
+              <div className="p-1 text-on-surface-variant">{trailingIcon}</div>
             </div>
           </div>
 
-          {elevation &&
+          {elevation && (
             <div
               className={classnames(
-                "opacity-0 bg-primary/8 absolute -top-full left-0 right-0 bottom-0",
-                "transition-all pointer-events-none z-0",
-                "md:ease-emphasized ease-emphasized-decelerate",
-                "duration-1000 md:duration-200",
+                "bg-primary/8 absolute -top-full left-0 right-0 bottom-0",
+                "pointer-events-none z-0",
+                "transition-opacity duration-200 md:duration-75",
                 "will-change-opacity",
-                elevationClassName,
+                elevationClassName
               )}
+              style={{
+                opacity: normalize(window.scrollY, 90, 100),
+              }}
             />
-          }
+          )}
         </div>
       </div>
-    );
-  });
-CompactHeadline.displayName = "CompactHeadline";
+      {/* Placeholder Div */}
+      <div className="opacity-0" style={{ height: "5.216rem" }} />
+    </>
+  );
+};
 
 export default CompactHeadline;
 export type { CompactHeadlineProp };

--- a/client/src/components/AppTopBar/Headline.tsx
+++ b/client/src/components/AppTopBar/Headline.tsx
@@ -1,9 +1,39 @@
+import useScrollPosition from "@react-hook/window-scroll";
 import { ForwardedRef, HTMLAttributes, ReactElement, forwardRef } from "react";
 
 import { classnames } from "../../Utilities";
 
 import { SubtitleProp, TitleProp } from "./Subcomponents";
 
+const normalize = (val: number, min: number, max: number) =>
+  (val - min) / (max - min);
+
+const limit = (val: number, min: number, max: number) =>
+  Math.min(Math.max(val, min), max);
+
+const ReactiveTitle = ({ title, titleClassName }: HeadlineProp) => {
+  const scrollY = useScrollPosition(20);
+
+  return (
+    <h1
+      className={classnames(
+        "text-on-surface font-headline font-bold",
+        "text-3xl md:text-4xl",
+        "transition-all duration-200 ease-emphasized origin-bottom-left will-change-transform",
+        titleClassName
+      )}
+      style={{
+        transform: `scale(${limit(
+          1 + normalize(scrollY, 0, -window.innerHeight * 4),
+          1,
+          1.1
+        )})`,
+      }}
+    >
+      {title}
+    </h1>
+  );
+};
 
 interface HeadlineProp extends Omit<HTMLAttributes<HTMLDivElement>, "title"> {
   title?: ReactElement<TitleProp>;
@@ -14,37 +44,45 @@ interface HeadlineProp extends Omit<HTMLAttributes<HTMLDivElement>, "title"> {
 
 const Headline = forwardRef<HTMLDivElement, HeadlineProp>(
   (
-    { title, titleClassName, subtitle, subtitleClassName, ...args }: HeadlineProp,
+    {
+      title,
+      titleClassName,
+      subtitle,
+      subtitleClassName,
+      ...args
+    }: HeadlineProp,
     ref: ForwardedRef<HTMLDivElement>
   ) => {
     return (
-      <div {...args} className={classnames("overflow-hidden", args.className)} ref={ref}>
+      <div
+        {...args}
+        className={classnames("overflow-hidden", args.className)}
+        ref={ref}
+      >
         <div
           className={classnames(
             "flex flex-row items-center pb-2 bg-surface",
-            "px-4.5 md:px-4",
+            "px-4.5 md:px-4"
           )}
         >
           <div className="grow space-y-1">
-            <h1 className={classnames(
-              "text-on-surface font-headline font-bold", "text-3xl md:text-4xl",
-              "transition-opacity duration-100 ease-emphasized-accelerate opacity-0",
-              titleClassName
-            )}>
-              {title}
-            </h1>
-            <h2 className={classnames(
-              "text-outline font-medium", "text-lg md:text-xl",
-              "transition-opacity duration-100 ease-emphasized-accelerate opacity-0",
-              subtitleClassName
-            )}>
+            <ReactiveTitle title={title} titleClassName={titleClassName} />
+            <h2
+              className={classnames(
+                "text-outline font-medium",
+                "text-lg md:text-xl",
+                "transition-opacity duration-100 ease-emphasized-accelerate",
+                subtitleClassName
+              )}
+            >
               {subtitle}
             </h2>
           </div>
         </div>
       </div>
     );
-  });
+  }
+);
 Headline.displayName = "Headline";
 
 export default Headline;


### PR DESCRIPTION
Combination of `window.addListener` with `onUpdate` hook for reactive scrolling effect seem to create performance bottleneck on the app. The hook seem to not perform `removeListener` properly to destroy unused listeners and return memory, and the app gets laggy as using. 

This PR includes:
1. Update only necessary sub-components rather than the entire `AppTopBar`, re-render fewer things on each scroll update
2. Rubber band effect on `Title`, better adapting iOS
3. Refactor / simplify code


https://user-images.githubusercontent.com/20573623/226211723-ef8273d8-74af-4b4d-996c-0b8b5a688467.mp4

